### PR TITLE
don't check for openssl libcrypto by default on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,11 +45,14 @@ CFLAGS+=" -D TSSCHECKER_VERSION_SHA=\\\"$(git rev-parse HEAD | tr -d '\n')\\\""
 # Checks for libraries.
 AC_ARG_WITH(
     [libcrypto],
-    [AS_HELP_STRING([--with-libcrypto], [build with libcrypto (default for non-Mac)])],
+    [AS_HELP_STRING([--with-libcrypto], [build with libcrypto (default for non-Mac/Windows)])],
     [],
     [
         case "${host_os}" in
             darwin*)
+                with_libcrypto=no
+                ;;
+            cygwin*|mingw*)
                 with_libcrypto=no
                 ;;
             *)


### PR DESCRIPTION
1Conan/tsschecker uses winapi bcrypt for it's hashing functions on Windows so it is unnecessary for configure to check for openssl libcrypto by default on Windows.

Fixes `Package requirements (libcrypto >= 1.0) were not met`

Configure will only check for openssl libcrypto if you specify `--with-libcrypto`
or it'll still be default if you are using a non-Windows/Mac platform (e.g Linux).

Tested on MSYS2 Mingw64 without openssl installed and was able to fully build tsschecker and dependencies with no trouble whatsoever.