### PR TITLE
fixed undefined vars of ver

### DIFF
--- a/tsschecker/tsschecker.h
+++ b/tsschecker/tsschecker.h
@@ -13,6 +13,22 @@
 extern "C" {
 #endif
 
+#ifndef TSSCHECKER_VERSION_MAJOR
+#define TSSCHECKER_VERSION_MAJOR "0"
+#endif
+#ifndef TSSCHECKER_VERSION_COUNT
+#define TSSCHECKER_VERSION_COUNT "0"
+#endif
+#ifndef TSSCHECKER_VERSION_PATCH
+#define TSSCHECKER_VERSION_PATCH "0"
+#endif
+#ifndef TSSCHECKER_VERSION_SHA
+#define TSSCHECKER_VERSION_SHA "0"
+#endif
+#ifndef TSSCHECKER_BUILD_TYPE
+#define TSSCHECKER_BUILD_TYPE "0"
+#endif
+
 #include <stdio.h>
 #include <plist/plist.h>
 


### PR DESCRIPTION
This small patch fixes the issue were configuration does not return the version info from subshell:
```Bash
./configure: 13199: CFLAGS+= -D TSSCHECKER_VERSION_COUNT=\"431\": not found
./configure: 13200: CFLAGS+= -D TSSCHECKER_VERSION_SHA=\"75f5c11420946c9d2b6ce3bacb35f0b7beddc84a\": not found
```

I have already seen this issue before in: [pzb](https://github.com/tihmstar/partialZipBrowser/pull/11)

I have investigate about it for a while, but until now I don't know why it's happening.