### PR TITLE
Support MOAR Devices

### DIFF
--- a/tsschecker/tsschecker.c
+++ b/tsschecker/tsschecker.c
@@ -127,23 +127,53 @@ int erase_install = 0;
 int save_bplist = 0;
 const char *shshSavePath = "."DIRECTORY_DELIMITER_STR;
 
-// iPhone & iPod touch (1st generations) do not use SHSH or APTicket.
+// iPhone & iPod touch 1st generation models do not use SHSH or APTicket.
 static struct bbdevice bbdevices[] = {
     // Apple Silicon Macs
-    {"ADP3,2", 0, 0},         // DTK (2020)
-    {"iMac21,1", 0, 0},       // iMac (24-inch, M1, 2021)
-    {"iMac21,2", 0, 0},       // iMac (24-inch, M1, 2021)
-    {"Macmini9,1", 0, 0},     // Mac Mini (M1, 2020)
-    {"MacBookAir10,1", 0, 0}, // MacBook Air (M1, 2020)
-    {"MacBookPro17,1", 0, 0}, // MacBook Pro (13-inch, M1, 2020)
-    {"MacBookPro18,1", 0, 0}, // MacBook Pro (M1 Pro, 16-inch, 2021)
-    {"MacBookPro18,2", 0, 0}, // MacBook Pro (M1 Max, 16-inch, 2021)
-    {"MacBookPro18,3", 0, 0}, // MacBook Pro (M1 Pro, 14-inch, 2021)
-    {"MacBookPro18,4", 0, 0}, // MacBook Pro (M1 Max, 14-inch, 2021)
-    {"Mac13,1", 0, 0},        // Mac Studio (M1 Max, 2022)
-    {"Mac13,2", 0, 0},        // Mac Studio (M1 Ultra, 2022)
-    {"Mac14,2", 0, 0},        // MacBook Air (M2, 2022)
-    {"Mac14,7", 0, 0},        // MacBook Pro (13-inch, M2, 2022)
+    {"ADP3,2", 0, 0},          // DTK (2020)
+    {"iMac21,1", 0, 0},        // iMac (24-inch, M1, 2021)
+    {"iMac21,2", 0, 0},        // iMac (24-inch, M1, 2021)
+    {"Macmini9,1", 0, 0},      // Mac Mini (M1, 2020)
+    {"MacBookAir10,1", 0, 0},  // MacBook Air (M1, 2020)
+    {"MacBookPro17,1", 0, 0},  // MacBook Pro (13-inch, M1, 2020)
+    {"MacBookPro18,1", 0, 0},  // MacBook Pro (M1 Pro, 16-inch, 2021)
+    {"MacBookPro18,2", 0, 0},  // MacBook Pro (M1 Max, 16-inch, 2021)
+    {"MacBookPro18,3", 0, 0},  // MacBook Pro (M1 Pro, 14-inch, 2021)
+    {"MacBookPro18,4", 0, 0},  // MacBook Pro (M1 Max, 14-inch, 2021)
+    {"Mac13,1", 0, 0},         // Mac Studio (M1 Max, 2022)
+    {"Mac13,2", 0, 0},         // Mac Studio (M1 Ultra, 2022)
+    {"Mac14,2", 0, 0},         // MacBook Air (M2, 2022)
+    {"Mac14,7", 0, 0},         // MacBook Pro (13-inch, M2, 2022)
+    {"Mac14,3", 0, 0},         // Mac mini (M2, 2023)
+    {"Mac14,5", 0, 0},         // MacBook Pro (14-inch, M2 Max, 2023)
+    {"Mac14,6", 0, 0},         // MacBook Pro (16-inch, M2 Max, 2023)
+    {"Mac14,8", 0, 0},         // Mac Pro (M2 Ultra, 2023)
+    {"Mac14,9", 0, 0},         // MacBook Pro (14-inch, M2 Pro, 2023)
+    {"Mac14,10", 0, 0},        // MacBook Pro (16-inch, M2 Pro, 2023)
+    {"Mac14,12", 0, 0},        // Mac mini (M2 Pro, 2023)
+    {"Mac14,13", 0, 0},        // Mac Studio (M2 Pro, 2023)
+    {"Mac14,14", 0, 0},        // Mac Studio (M2 Ultra, 2023)
+    {"Mac14,15", 0, 0},        // MacBook Air (15-inch, M2, 2023)
+    {"Mac15,3", 0, 0},         // MacBook Pro (14-inch, M3, Nov 2023)
+    {"Mac15,4", 0, 0},         // iMac 24-inch (M3, Two Ports, 2023)
+    {"Mac15,5", 0, 0},         // iMac 24-inch (M3, Four Ports, 2023)
+    {"Mac15,6", 0, 0},         // MacBook Pro (14-inch, M3 Pro, Nov 2023)
+    {"Mac15,7", 0, 0},         // MacBook Pro (16-inch, M3 Pro, Nov 2023)
+    {"Mac15,8", 0, 0},         // MacBook Pro (14-inch, M3 Max, Nov 2023)
+    {"Mac15,9", 0, 0},         // MacBook Pro (16-inch, M3 Max, Nov 2023)
+    {"Mac15,10", 0, 0},        // MacBook Pro (14-inch, M3 Max, Nov 2023)
+    {"Mac15,11", 0, 0},        // MacBook Pro (16-inch, M3 Max, Nov 2023)
+    {"Mac15,12", 0, 0},        // MacBook Air (13-inch, M3, 2024)
+    {"Mac15,13", 0, 0},        // MacBook Air (15-inch, M3, 2024)
+    {"Mac16,1", 0, 0},         // MacBook Pro (14-inch, M4, Nov 2024)
+    {"Mac16,2", 0, 0},         // iMac 24-inch (M4, Two Ports, 2024)
+    {"Mac16,3", 0, 0},         // iMac 24-inch (M4, Four Ports, 2024)
+    {"Mac16,5", 0, 0},         // MacBook Pro (16-inch, M4 Pro, Nov 2024)
+    {"Mac16,6", 0, 0},         // MacBook Pro (14-inch, M4 Pro, Nov 2024)
+    {"Mac16,7", 0, 0},         // MacBook Pro (16-inch, M4 Pro, Nov 2024)
+    {"Mac16,8", 0, 0},         // MacBook Pro (14-inch, M4 Pro, Nov 2024)
+    {"Mac16,10", 0, 0},        // Mac mini (M4, 2024)
+    {"Mac16,11", 0, 0},        // Mac mini (M4 Pro, 2024)
 
     // Apple Displays
     {"AppleDisplay2,1", 0, 0}, // Studio Display
@@ -227,61 +257,71 @@ static struct bbdevice bbdevices[] = {
     {"iPhone15,5", 3452763205, 4},   // iPhone 15 Plus
     {"iPhone16,1", 3452763205, 4},   // iPhone 15 Pro
     {"iPhone16,2", 3452763205, 4},   // iPhone 15 Pro Max
+    {"iPhone17,1", 1652214800, 4},   // iPhone 16 Pro
+    {"iPhone17,2", 1652214800, 4},   // iPhone 16 Pro Max
+    {"iPhone17,3", 1652214800, 4},   // iPhone 16
+    {"iPhone17,4", 1652214800, 4},   // iPhone 16 Plus
 
     // iPads
-    {"iPad1,1",  0, 0},          // iPad (1st gen)
-    {"iPad2,1",  0, 0},          // iPad 2 Wi-Fi
-    {"iPad2,2",  257, 12},       // iPad 2 GSM
-    {"iPad2,3",  257, 12},       // iPad 2 CDMA
-    {"iPad2,4",  0, 0},          // iPad 2 Wi-Fi (2012, Rev A)
-    {"iPad3,1",  0, 0},          // iPad (3rd gen, Wi-Fi)
-    {"iPad3,2",  4, 4},          // iPad (3rd gen, CDMA)
-    {"iPad3,3",  4, 4},          // iPad (3rd gen, GSM)
-    {"iPad3,4",  0, 0},          // iPad with Retina display (4th gen, Wi-Fi)
-    {"iPad3,5",  3255536192, 4}, // iPad with Retina display (4th gen, CDMA)
-    {"iPad3,6",  3255536192, 4}, // iPad with Retina display (4th gen, GSM)
-    {"iPad6,11", 0, 0},          // iPad (5th gen, 2017, Wi-Fi)
-    {"iPad6,12", 3840149528, 4}, // iPad (5th gen, 2017, Cellular)
-    {"iPad7,5",  0, 0},          // iPad (6th gen, 2018, Wi-Fi)
-    {"iPad7,6",  3840149528, 4}, // iPad (6th gen, 2018, Cellular)
-    {"iPad7,11", 0, 0},          // iPad (7th gen, 2019, Wi-Fi)
-    {"iPad7,12", 165673526, 12}, // iPad (7th gen, 2019, Cellular)
-    {"iPad11,6", 0, 0},          // iPad (8th gen, 2020, Wi-Fi)
-    {"iPad11,7", 165673526, 12}, // iPad (8th gen, 2020, Cellular)
-    {"iPad12,1", 0, 0},          // iPad (9th gen, 2021, Wi-Fi)
-    {"iPad12,2", 165673526, 12}, // iPad (9th gen, 2021, Cellular)
-    {"iPad13,18", 0, 0},         // iPad (10th gen, 2022, Wi-Fi)
-    {"iPad13,19", 495958265, 4}, // iPad (10th gen, 2022, Cellular)
+    {"iPad1,1",    0, 0},            // iPad (1st gen)
+    {"iPad2,1",    0, 0},            // iPad 2 Wi-Fi
+    {"iPad2,2",    257, 12},         // iPad 2 GSM
+    {"iPad2,3",    257, 12},         // iPad 2 CDMA
+    {"iPad2,4",    0, 0},            // iPad 2 Wi-Fi (2012, Rev A)
+    {"iPad3,1",    0, 0},            // iPad (3rd gen, Wi-Fi)
+    {"iPad3,2",    4, 4},            // iPad (3rd gen, CDMA)
+    {"iPad3,3",    4, 4},            // iPad (3rd gen, GSM)
+    {"iPad3,4",    0, 0},            // iPad with Retina display (4th gen, Wi-Fi)
+    {"iPad3,5",    3255536192, 4},   // iPad with Retina display (4th gen, CDMA)
+    {"iPad3,6",    3255536192, 4},   // iPad with Retina display (4th gen, GSM)
+    {"iPad6,11",   0, 0},            // iPad (5th gen, 2017, Wi-Fi)
+    {"iPad6,12",   3840149528, 4},   // iPad (5th gen, 2017, Cellular)
+    {"iPad7,5",    0, 0},            // iPad (6th gen, 2018, Wi-Fi)
+    {"iPad7,6",    3840149528, 4},   // iPad (6th gen, 2018, Cellular)
+    {"iPad7,11",   0, 0},            // iPad (7th gen, 2019, Wi-Fi)
+    {"iPad7,12",   165673526, 12},   // iPad (7th gen, 2019, Cellular)
+    {"iPad11,6",   0, 0},            // iPad (8th gen, 2020, Wi-Fi)
+    {"iPad11,7",   165673526, 12},   // iPad (8th gen, 2020, Cellular)
+    {"iPad12,1",   0, 0},            // iPad (9th gen, 2021, Wi-Fi)
+    {"iPad12,2",   165673526, 12},   // iPad (9th gen, 2021, Cellular)
+    {"iPad13,18",  0, 0},            // iPad (10th gen, 2022, Wi-Fi)
+    {"iPad13,19",  495958265, 4},    // iPad (10th gen, 2022, Cellular)
 
     // iPad minis
-    {"iPad2,5",  0, 0},          // iPad mini (1st gen, Wi-Fi)
-    {"iPad2,6",  3255536192, 4}, // iPad mini (1st gen, CDMA)
-    {"iPad2,7",  3255536192, 4}, // iPad mini (1st gen, GSM)
-    {"iPad4,4",  0, 0},          // iPad mini 2 (Wi-Fi)
-    {"iPad4,5",  3554301762, 4}, // iPad mini 2 (Cellular)
-    {"iPad4,6",  3554301762, 4}, // iPad mini 2 (Cellular, China)
-    {"iPad4,7",  0, 0},          // iPad mini 3 (Wi-Fi)
-    {"iPad4,8",  3554301762, 4}, // iPad mini 3 (Cellular)
-    {"iPad4,9",  3554301762, 4}, // iPad mini 3 (Cellular, China)
-    {"iPad5,1",  0, 0},          // iPad mini 4 (Wi-Fi)
-    {"iPad5,2",  3840149528, 4}, // iPad mini 4 (Cellular)
-    {"iPad11,1", 0, 0},          // iPad mini (5th gen, Wi-Fi)
-    {"iPad11,2", 165673526, 12}, // iPad mini (5th gen, Cellular)
-    {"iPad14,1", 0, 0},          // iPad mini (6th gen, Wi-Fi)
-    {"iPad14,2", 495958265, 4},  // iPad mini (6th gen, Cellular)
+    {"iPad2,5",    0, 0},            // iPad mini (1st gen, Wi-Fi)
+    {"iPad2,6",    3255536192, 4},   // iPad mini (1st gen, CDMA)
+    {"iPad2,7",    3255536192, 4},   // iPad mini (1st gen, GSM)
+    {"iPad4,4",    0, 0},            // iPad mini 2 (Wi-Fi)
+    {"iPad4,5",    3554301762, 4},   // iPad mini 2 (Cellular)
+    {"iPad4,6",    3554301762, 4},   // iPad mini 2 (Cellular, China)
+    {"iPad4,7",    0, 0},            // iPad mini 3 (Wi-Fi)
+    {"iPad4,8",    3554301762, 4},   // iPad mini 3 (Cellular)
+    {"iPad4,9",    3554301762, 4},   // iPad mini 3 (Cellular, China)
+    {"iPad5,1",    0, 0},            // iPad mini 4 (Wi-Fi)
+    {"iPad5,2",    3840149528, 4},   // iPad mini 4 (Cellular)
+    {"iPad11,1",   0, 0},            // iPad mini (5th gen, Wi-Fi)
+    {"iPad11,2",   165673526, 12},   // iPad mini (5th gen, Cellular)
+    {"iPad14,1",   0, 0},            // iPad mini (6th gen, Wi-Fi)
+    {"iPad14,2",   495958265, 4},    // iPad mini (6th gen, Cellular)
+    {"iPad16,1",   0, 0},            // iPad mini (A17 Pro, Wi-Fi)
+    {"iPad16,2",   3452763205, 4},   // iPad mini (A17 Pro, Cellular)
 
     // iPad Airs
-    {"iPad4,1",  0, 0},          // iPad Air (Wi-Fi)
-    {"iPad4,2",  3554301762, 4}, // iPad Air (Cellular)
-    {"iPad4,3",  3554301762, 4}, // iPad Air (Cellular, China)
-    {"iPad5,3",  0, 0},          // iPad Air 2 (Wi-Fi)
-    {"iPad5,4",  3840149528, 4}, // iPad Air 2 (Cellular)
-    {"iPad11,3", 0, 0},          // iPad Air (3rd gen, Wi-Fi)
-    {"iPad11,4", 165673526, 12}, // iPad Air (3rd gen, Cellular)
-    {"iPad13,1", 0, 0},          // iPad Air (4th gen, Wi-Fi)
-    {"iPad13,2", 524245983, 12}, // iPad Air (4th gen, Cellular)
-    {"iPad13,16", 0, 0},         // iPad Air (5th gen, Wi-Fi)
-    {"iPad13,17", 495958265, 4}, // iPad Air (5th gen, Cellular)
+    {"iPad4,1",    0, 0},            // iPad Air (Wi-Fi)
+    {"iPad4,2",    3554301762, 4},   // iPad Air (Cellular)
+    {"iPad4,3",    3554301762, 4},   // iPad Air (Cellular, China)
+    {"iPad5,3",    0, 0},            // iPad Air 2 (Wi-Fi)
+    {"iPad5,4",    3840149528, 4},   // iPad Air 2 (Cellular)
+    {"iPad11,3",   0, 0},            // iPad Air (3rd gen, Wi-Fi)
+    {"iPad11,4",   165673526, 12},   // iPad Air (3rd gen, Cellular)
+    {"iPad13,1",   0, 0},            // iPad Air (4th gen, Wi-Fi)
+    {"iPad13,2",   524245983, 12},   // iPad Air (4th gen, Cellular)
+    {"iPad13,16",  0, 0},            // iPad Air (5th gen, Wi-Fi)
+    {"iPad13,17",  495958265, 4},    // iPad Air (5th gen, Cellular)
+    {"iPad14,8",   0, 0},            // iPad Air (11-inch, M2, Wi-Fi)
+    {"iPad14,9",   495958265, 4},    // iPad Air (11-inch, M2, Cellular)
+    {"iPad14,10",  0, 0},            // iPad Air (13-inch, M2, Wi-Fi)
+    {"iPad14,11",  495958265, 4},    // iPad Air (13-inch, M2, Cellular)
 
     // iPad Pros
     {"iPad6,3",    0, 0},            // iPad Pro (9.7-inch, Wi-Fi)
@@ -316,6 +356,10 @@ static struct bbdevice bbdevices[] = {
     {"iPad14,4",   3559316616, 4},   // iPad Pro (11-inch, 4th gen, Cellular)
     {"iPad14,5",   0, 0},            // iPad Pro (12.9-inch, 6th gen, Wi-Fi)
     {"iPad14,6",   3559316616, 4},   // iPad Pro (12.9-inch, 6th gen, Cellular)
+    {"iPad16,3",   0, 0},            // iPad Pro (11-inch, M4, Wi-Fi)
+    {"iPad16,4",   3452763205, 4},   // iPad Pro (11-inch, M4, Cellular)
+    {"iPad16,5",   0, 0},            // iPad Pro (13-inch, M4, Wi-Fi)
+    {"iPad16,6",   3452763205, 4},   // iPad Pro (13-inch, M4, Cellular)
 
     // Apple Watches
     {"Watch1,1",   0, 0},            // Apple Watch 1st gen (38mm)
@@ -362,19 +406,24 @@ static struct bbdevice bbdevices[] = {
     {"Watch7,3",   744114402, 12},   // Apple Watch Series 9 (41mm, GPS + Cellular)
     {"Watch7,4",   744114402, 12},   // Apple Watch Series 9 (45mm, GPS + Cellular)
     {"Watch7,5",   744114402, 12},   // Apple Watch Ultra 2 (49mm, GPS + Cellular)
+    {"Watch7,8",   0, 0},            // Apple Watch Series 10 (42mm, GPS)
+    {"Watch7,9",   0, 0},            // Apple Watch Series 10 (46mm, GPS)
+    {"Watch7,10",  744114402, 12},   // Apple Watch Series 10 (42mm, GPS + Cellular)
+    {"Watch7,11",  744114402, 12},   // Apple Watch Series 10 (46mm, GPS + Cellular)
 
     // HomePods
     {"AudioAccessory1,1",   0, 0},   // HomePod 1st gen
     {"AudioAccessory1,2",   0, 0},   // HomePod 1st gen (2018)
     {"AudioAccessory5,1",   0, 0},   // HomePod mini
-    
+    {"AudioAccessory6,1",   0, 0},   // HomePod 2nd gen
+
     // Apple TVs
     {"AppleTV1,1",   0, 0},  // 1st gen
     {"AppleTV2,1",   0, 0},  // 2nd gen
     {"AppleTV3,1",   0, 0},  // 3rd gen
     {"AppleTV3,2",   0, 0},  // 3rd gen (2013)
     {"AppleTV5,3",   0, 0},  // 4th gen
-    {"AppleTV6,2",   0, 0},  // 4K
+    {"AppleTV6,2",   0, 0},  // 4K 1st gen
     {"AppleTV11,1",  0, 0},  // 4K 2nd gen
     {"AppleTV14,1",  0, 0},  // 4K 3rd gen
     {NULL, 0, 0}
@@ -1475,36 +1524,45 @@ int isManifestBufSignedForDevice(char *buildManifestBuffer, t_devicevals *devVal
              * Apple Tatsu moment
              * The apple Tatsu servers are wack
             */
-            if(devVals->deviceBoard && (!strcasecmp(devVals->deviceBoard, "d83ap") || !strcasecmp(devVals->deviceBoard, "d84ap")
+            if(devVals->deviceBoard && (!strcasecmp(devVals->deviceBoard, "n51ap") || !strcasecmp(devVals->deviceBoard, "n53ap")
+                                        || !strcasecmp(devVals->deviceBoard, "n56ap") || !strcasecmp(devVals->deviceBoard, "n61ap")
                                         || !strcasecmp(devVals->deviceBoard, "d73ap") || !strcasecmp(devVals->deviceBoard, "d74ap")
                                         || !strcasecmp(devVals->deviceBoard, "d37ap") || !strcasecmp(devVals->deviceBoard, "d38ap")
-                                        || !strcasecmp(devVals->deviceBoard, "n51ap") || !strcasecmp(devVals->deviceBoard, "n53ap")
-                                        || !strcasecmp(devVals->deviceBoard, "n56ap") || !strcasecmp(devVals->deviceBoard, "n61ap")
-                                        || !strcasecmp(devVals->deviceBoard, "j71ap") || !strcasecmp(devVals->deviceBoard, "j72ap")
-                                        || !strcasecmp(devVals->deviceBoard, "j73ap") || !strcasecmp(devVals->deviceBoard, "j81ap")
-                                        || !strcasecmp(devVals->deviceBoard, "j82ap") || !strcasecmp(devVals->deviceBoard, "n102ap")
+                                        || !strcasecmp(devVals->deviceBoard, "d83ap") || !strcasecmp(devVals->deviceBoard, "d84ap")
+                                        || !strcasecmp(devVals->deviceBoard, "d93ap") || !strcasecmp(devVals->deviceBoard, "d94ap")
+                                        || !strcasecmp(devVals->deviceBoard, "d47ap") || !strcasecmp(devVals->deviceBoard, "d48ap")
+                                        || !strcasecmp(devVals->deviceBoard, "n102ap") || !strcasecmp(devVals->deviceBoard, "j71ap")
+                                        || !strcasecmp(devVals->deviceBoard, "j72ap") || !strcasecmp(devVals->deviceBoard, "j73ap")
                                         || !strcasecmp(devVals->deviceBoard, "j85ap") || !strcasecmp(devVals->deviceBoard, "j86ap")
                                         || !strcasecmp(devVals->deviceBoard, "j87ap") || !strcasecmp(devVals->deviceBoard, "j85map")
                                         || !strcasecmp(devVals->deviceBoard, "j86map") || !strcasecmp(devVals->deviceBoard, "j87map")
                                         || !strcasecmp(devVals->deviceBoard, "j96ap") || !strcasecmp(devVals->deviceBoard, "j97ap")
-                                        || !strcasecmp(devVals->deviceBoard, "n112ap") || !strcasecmp(devVals->deviceBoard, "j42dap")
-                                        || !strcasecmp(devVals->deviceBoard, "j105aap") || !strcasecmp(devVals->deviceBoard, "j305ap"))) {
+                                        || !strcasecmp(devVals->deviceBoard, "j81ap") || !strcasecmp(devVals->deviceBoard, "j82ap")
+                                        || !strcasecmp(devVals->deviceBoard, "j717ap") || !strcasecmp(devVals->deviceBoard, "j718ap")
+                                        || !strcasecmp(devVals->deviceBoard, "j720ap") || !strcasecmp(devVals->deviceBoard, "j721ap")
+                                        || !strcasecmp(devVals->deviceBoard, "j42dap") || !strcasecmp(devVals->deviceBoard, "j105aap")
+                                        || !strcasecmp(devVals->deviceBoard, "j305ap") || !strcasecmp(devVals->deviceBoard, "j255ap"))) {
                 save_apticket3 = false;
             }
-            if(devVals->deviceModel && (!strcasecmp(devVals->deviceModel, "iPhone16,1") || !strcasecmp(devVals->deviceModel, "iPhone16,2")
+            if(devVals->deviceModel && (!strcasecmp(devVals->deviceModel, "iPhone6,1") || !strcasecmp(devVals->deviceModel, "iPhone6,2")
+                                        || !strcasecmp(devVals->deviceModel, "iPhone7,1") || !strcasecmp(devVals->deviceModel, "iPhone7,2")
                                         || !strcasecmp(devVals->deviceModel, "iPhone15,2") || !strcasecmp(devVals->deviceModel, "iPhone15,3")
                                         || !strcasecmp(devVals->deviceModel, "iPhone15,4") || !strcasecmp(devVals->deviceModel, "iPhone15,5")
-                                        || !strcasecmp(devVals->deviceModel, "iPhone6,1") || !strcasecmp(devVals->deviceModel, "iPhone6,2")
-                                        || !strcasecmp(devVals->deviceModel, "iPhone7,1") || !strcasecmp(devVals->deviceModel, "iPhone7,2")
-                                        || !strcasecmp(devVals->deviceModel, "iPad4,1") || !strcasecmp(devVals->deviceModel, "iPad4,2")
-                                        || !strcasecmp(devVals->deviceModel, "iPad4,3") || !strcasecmp(devVals->deviceModel, "iPad5,3")
-                                        || !strcasecmp(devVals->deviceModel, "iPad5,4") || !strcasecmp(devVals->deviceModel, "iPod7,1")
+                                        || !strcasecmp(devVals->deviceModel, "iPhone16,1") || !strcasecmp(devVals->deviceModel, "iPhone16,2")
+                                        || !strcasecmp(devVals->deviceModel, "iPhone17,1") || !strcasecmp(devVals->deviceModel, "iPhone17,2")
+                                        || !strcasecmp(devVals->deviceModel, "iPhone17,3") || !strcasecmp(devVals->deviceModel, "iPhone17,4")
+                                        || !strcasecmp(devVals->deviceModel, "iPod7,1") || !strcasecmp(devVals->deviceModel, "iPad4,1")
+                                        || !strcasecmp(devVals->deviceModel, "iPad4,2") || !strcasecmp(devVals->deviceModel, "iPad4,3")
                                         || !strcasecmp(devVals->deviceModel, "iPad4,4") || !strcasecmp(devVals->deviceModel, "iPad4,5")
                                         || !strcasecmp(devVals->deviceModel, "iPad4,6") || !strcasecmp(devVals->deviceModel, "iPad4,7")
                                         || !strcasecmp(devVals->deviceModel, "iPad4,8") || !strcasecmp(devVals->deviceModel, "iPad4,9")
                                         || !strcasecmp(devVals->deviceModel, "iPad5,1") || !strcasecmp(devVals->deviceModel, "iPad5,2")
-                                        || !strcasecmp(devVals->deviceModel, "iPod9,1") || !strcasecmp(devVals->deviceModel, "Appletv5,3")
-                                        || !strcasecmp(devVals->deviceModel, "Appletv6,2") || !strcasecmp(devVals->deviceModel, "Appletv11,1"))) {
+                                        || !strcasecmp(devVals->deviceModel, "iPad5,3") || !strcasecmp(devVals->deviceModel, "iPad5,4")
+                                        || !strcasecmp(devVals->deviceModel, "iPad16,1") || !strcasecmp(devVals->deviceModel, "iPad16,2")
+                                        || !strcasecmp(devVals->deviceModel, "iPad16,3") || !strcasecmp(devVals->deviceModel, "iPad16,4")
+                                        || !strcasecmp(devVals->deviceModel, "iPad16,5") || !strcasecmp(devVals->deviceModel, "iPad16,6")
+                                        || !strcasecmp(devVals->deviceModel, "Appletv5,3") || !strcasecmp(devVals->deviceModel, "Appletv6,2")
+                                        || !strcasecmp(devVals->deviceModel, "Appletv11,1") || !strcasecmp(devVals->deviceModel, "Appletv14,1"))) {
                 save_apticket3 = false;
             }
             if(save_apticket3 && !tssrequest(&tssreq2, buildManifestBuffer, devVals, kBasebandModeWithoutBaseband)) {


### PR DESCRIPTION
Supports everything apple released in 2024, apple tatsu moments may apply.

* Apple Watch Series 10
* iPhone 16 model series
* iPad mini A17 Pro
* iPad Air M2
* iPad Pro M4
* iMac M4
* MacBook Air M3
* Mac mini (M4, 2024)
* Mac mini (M4 Pro, 2024)
* MacBook Pro M4 (Nov 2024)
* MacBook Pro M4 Pro (Nov 2024)

i also re-sorted the apnonce 3 exclusion list and removed iPod9,1 from it since that device isn't subject to error 128 or 456 when trying to request a ticket without a nonce.